### PR TITLE
Encryption Flag

### DIFF
--- a/CertServer/Controllers/IssueController.cs
+++ b/CertServer/Controllers/IssueController.cs
@@ -103,7 +103,7 @@ namespace CertServer.Controllers
 					// XXX: @Loris, agree with flags?
 					req.CertificateExtensions.Add(
 						new X509KeyUsageExtension(
-							X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.NonRepudiation,
+							X509KeyUsageFlags.KeyEncipherment | X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.NonRepudiation,
 							false
 						)
 					);


### PR DESCRIPTION
I think we should add this flag.
This flag is required for S/MIME[ 1]

[1] https://access.redhat.com/documentation/en-US/Red_Hat_Certificate_System/8.0/html/Admin_Guide/Standard_X.509_v3_Certificate_Extensions.html#Standard_X.509_v3_Certificate_Extensions-keyUsage