### PR TITLE
Add our root certificate to browser's root of trust

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -273,7 +273,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
                     # Initialize firefox so that its certificate DB is initialized
                     sudo su - #{CLIENT_UNAME} -c "timeout 3 firefox-esr -migration -no-remote -headless 2> /dev/null"
                     # Add our root CA to firefox root of trust
-                    sudo bash /vagrant/scripts/mozilla-import-certificates.sh "/home/#{CLIENT_UNAME}"
+                    sudo /vagrant/scripts/mozilla-import-certificates.sh "/home/#{CLIENT_UNAME}"
 
                     # Remove sensitive data from history
                     history -c

--- a/vagrant_share/scripts/mozilla-import-certificates.sh
+++ b/vagrant_share/scripts/mozilla-import-certificates.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ### Script installs root.cert.pem to certificate trust store of applications using NSS
 ### (e.g. Firefox, Thunderbird, Chromium)
@@ -14,8 +14,8 @@ homefolder="$1"
 
 for certDB in $(find $homefolder -name "cert8.db")
 do
-    echo "Add certificate '${certname}' to $certDB"
-    certdir=$(dirname ${certDB});
+    echo "Add certificate '${certname}' to '$certDB'"
+    certdir=$(dirname ${certDB})
     certutil -A -n "${certname}" -t "TCu,Cu,Tu" -i ${certfile} -d dbm:${certdir}
 done
 
@@ -26,7 +26,7 @@ done
 
 for certDB in $(find $homefolder -name "cert9.db")
 do
-    echo "Add certificate '${certname}' to $certDB"
-    certdir=$(dirname ${certDB});
+    echo "Add certificate '${certname}' to '$certDB'"
+    certdir=$(dirname ${certDB})
     certutil -A -n "${certname}" -t "TCu,Cu,Tu" -i ${certfile} -d sql:${certdir}
 done


### PR DESCRIPTION
This is far from a normal use case, therefore there is little tool support and the solution is a bit hacky.